### PR TITLE
3.2.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,13 +28,14 @@
     "dynamic color"
   ],
   "devDependencies": {
-    "@rollup/plugin-commonjs": "^22.0.0",
-    "@rollup/plugin-node-resolve": "^13.3.0",
+    "@rollup/plugin-commonjs": "^28.0.2",
+    "@rollup/plugin-node-resolve": "^16.0.0",
+    "@rollup/plugin-terser": "^0.4.4",
     "color": "^4.2.3",
-    "jest": "^27.2.4",
-    "postcss": "^8.2.4",
-    "rollup": "^2.79.1",
-    "rollup-plugin-terser": "^7.0.2",
+    "jest": "^29.7.0",
+    "jest-environment-jsdom": "^29.7.0",
+    "postcss": "^8.4.49",
+    "rollup": "^4.29.1",
     "tailwindcss": "^3.0.0"
   },
   "author": "Javier Morales",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "tailwind-mode-aware-colors": "^2.0.2"
   },
   "peerDependencies": {
-    "tailwindcss": "^3.0.0"
+    "tailwindcss": "^3.4.17"
   },
   "keywords": [
     "tailwind",
@@ -36,7 +36,7 @@
     "jest-environment-jsdom": "^29.7.0",
     "postcss": "^8.4.49",
     "rollup": "^4.29.1",
-    "tailwindcss": "^3.0.0"
+    "tailwindcss": "^3.4.17"
   },
   "author": "Javier Morales",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tailwind-material-colors",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "description": "TailwindCSS Plugin to use the Material 3 Color System with Tailwind",
   "main": "lib/index.min.cjs",
   "module": "lib/index.esm.js",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,8 +1,11 @@
 import resolve from "@rollup/plugin-node-resolve";
 import commonjs from "@rollup/plugin-commonjs";
-import { terser } from "rollup-plugin-terser";
+import terser from "@rollup/plugin-terser";
+import { readFileSync } from "node:fs";
 
-const packageJson = require("./package.json");
+const packageJson = JSON.parse(
+  readFileSync(new URL("./package.json", import.meta.url), "utf-8")
+);
 
 /**
  * @type {import('rollup').RollupOptions}

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -4,6 +4,9 @@ import { terser } from "rollup-plugin-terser";
 
 const packageJson = require("./package.json");
 
+/**
+ * @type {import('rollup').RollupOptions}
+ */
 export default [
   {
     input: "src/index.js",

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -27,18 +27,18 @@ it("Generates the correct light-mode CSS", async () => {
       }
       .bg-primary-light {
         --tw-bg-opacity: 1;
-        background-color: rgb(165 1 0 / var(--tw-bg-opacity))
+        background-color: rgb(165 1 0 / var(--tw-bg-opacity, 1))
       }
       .text-on-primary-light {
         --tw-text-opacity: 1;
-        color: rgb(255 255 255 / var(--tw-text-opacity))
+        color: rgb(255 255 255 / var(--tw-text-opacity, 1))
       }
       .bg-green-light\\/50 {
         --tw-bg-base: rgb(74 103 0 / 0.5)
       }
       .bg-primary-light {
         --tw-bg-opacity: 1;
-        --tw-bg-base: rgb(165 1 0 / var(--tw-bg-opacity))
+        --tw-bg-base: rgb(165 1 0 / var(--tw-bg-opacity, 1))
       }
     `.replace(/\n|\s|\t/g, "")
   );
@@ -49,18 +49,18 @@ it("Generates the correct light-mode CSS", async () => {
     `
       .bg-primary-light {
         --tw-text-opacity: 1;
-        color: rgb(255 255 255 / var(--tw-text-opacity))
+        color: rgb(255 255 255 / var(--tw-text-opacity, 1))
       }
       .interactive-bg-primary-light {
-        background-color: rgb(165 1 0 / var(--tw-bg-opacity));
+        background-color: rgb(165 1 0 / var(--tw-bg-opacity, 1));
         --tw-bg-opacity: 1;
-        --tw-bg-base: rgb(165 1 0 / var(--tw-bg-opacity));
+        --tw-bg-base: rgb(165 1 0 / var(--tw-bg-opacity, 1));
         --tw-text-opacity: 1;
-        color: rgb(255 255 255 / var(--tw-text-opacity));
+        color: rgb(255 255 255 / var(--tw-text-opacity, 1));
         --tw-bg-mix-opacity: 1;
         background-color: color-mix(
           var(--tw-bg-mix-method, in srgb),
-          rgb(255 255 255 / var(--tw-bg-mix-opacity)) calc(var(--tw-bg-mix-amount, 0) * 1%),
+          rgb(255 255 255 / var(--tw-bg-mix-opacity, 1)) calc(var(--tw-bg-mix-amount, 0) * 1%),
           var(--tw-bg-base)
         );
         transition-property: color, background-color, border-color, text-decoration-color, fill, stroke;
@@ -123,18 +123,18 @@ it("Generates the correct mode-aware CSS", async () => {
       }
       .bg-primary {
         --tw-bg-opacity: 1;
-        background-color: rgb(var(--color-primary) / var(--opacity-primary, var(--tw-bg-opacity)))
+        background-color: rgb(var(--color-primary) / var(--opacity-primary, var(--tw-bg-opacity, 1)))
       }
       .text-on-primary {
         --tw-text-opacity: 1;
-        color: rgb(var(--color-on-primary) / var(--opacity-on-primary, var(--tw-text-opacity)))
+        color: rgb(var(--color-on-primary) / var(--opacity-on-primary, var(--tw-text-opacity, 1)))
       }
       .bg-green\\/50 {
         --tw-bg-base: rgb(var(--color-green) / 0.5)
       }
       .bg-primary {
         --tw-bg-opacity: 1;
-        --tw-bg-base: rgb(var(--color-primary) / var(--opacity-primary, var(--tw-bg-opacity)))
+        --tw-bg-base: rgb(var(--color-primary) / var(--opacity-primary, var(--tw-bg-opacity, 1)))
       }
     `.replace(/\n|\s|\t/g, "")
   );
@@ -145,18 +145,18 @@ it("Generates the correct mode-aware CSS", async () => {
     `
       .bg-primary {
         --tw-text-opacity: 1;
-        color: rgb(var(--color-on-primary) / var(--opacity-on-primary, var(--tw-text-opacity)))
+        color: rgb(var(--color-on-primary) / var(--opacity-on-primary, var(--tw-text-opacity, 1)))
       }
       .interactive-bg-primary {
-        background-color: rgb(var(--color-primary) / var(--opacity-primary, var(--tw-bg-opacity)));
+        background-color: rgb(var(--color-primary) / var(--opacity-primary, var(--tw-bg-opacity, 1)));
         --tw-bg-opacity: 1;
-        --tw-bg-base: rgb(var(--color-primary) / var(--opacity-primary, var(--tw-bg-opacity)));
+        --tw-bg-base: rgb(var(--color-primary) / var(--opacity-primary, var(--tw-bg-opacity, 1)));
         --tw-text-opacity: 1;
-        color: rgb(var(--color-on-primary) / var(--opacity-on-primary, var(--tw-text-opacity)));
+        color: rgb(var(--color-on-primary) / var(--opacity-on-primary, var(--tw-text-opacity, 1)));
         --tw-bg-mix-opacity: 1;
         background-color: color-mix(
           var(--tw-bg-mix-method, in srgb),
-          rgb(var(--color-on-primary) / var(--opacity-on-primary, var(--tw-bg-mix-opacity))) calc(var(--tw-bg-mix-amount, 0) * 1%),
+          rgb(var(--color-on-primary) / var(--opacity-on-primary, var(--tw-bg-mix-opacity, 1))) calc(var(--tw-bg-mix-amount, 0) * 1%),
           var(--tw-bg-base)
         );
         transition-property: color, background-color, border-color, text-decoration-color, fill, stroke;


### PR DESCRIPTION
- update packages
- match `tailwindcss` version in `peerDependencies`
- add config type to `rollup.config.js`
- fix tests

I tried to update `@material/material-color-utilities` to 0.3.0, but some colors were off a little bit (and `updateTheme` broke,  but it should be fixable). Let it be up to you whether to update this package or not

I'm going to work on #9 soon